### PR TITLE
Twilio advanced settings text entry

### DIFF
--- a/LoopFollow/ViewControllers/RemoteSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/RemoteSettingsViewController.swift
@@ -38,36 +38,46 @@ class RemoteSettingsViewController: FormViewController {
         remoteCommandsSection 
         <<< TextRow("twilioSID"){ row in
             row.title = "Twilio SID"
-            let maskedSID = String(repeating: "*", count: UserDefaultsRepository.twilioSIDString.value.count)
-            row.value = maskedSID
+            row.cell.textField.placeholder = "EnterSID"
+            if (UserDefaultsRepository.twilioSIDString.value != "") {
+                let maskedSecret = String(repeating: "*", count: UserDefaultsRepository.twilioSIDString.value.count)
+                row.value = maskedSecret
+            }
         }.onChange { row in
-            guard let value = row.value else { return }
-            UserDefaultsRepository.twilioSIDString.value = value
+            UserDefaultsRepository.twilioSIDString.value = row.value ?? ""
         }
         
         <<< TextRow("twilioSecret"){ row in
             row.title = "Twilio Secret"
-            let maskedSecret = String(repeating: "*", count: UserDefaultsRepository.twilioSecretString.value.count)
-            row.value = maskedSecret
+            row.cell.textField.placeholder = "EnterSecret"
+            if (UserDefaultsRepository.twilioSecretString.value != "") {
+                let maskedSecret = String(repeating: "*", count: UserDefaultsRepository.twilioSecretString.value.count)
+                row.value = maskedSecret
+            }
         }.onChange { row in
-            guard let value = row.value else { return }
-            UserDefaultsRepository.twilioSecretString.value = value
+            UserDefaultsRepository.twilioSecretString.value = row.value ?? ""
         }
         
         <<< TextRow("twilioFromNumberString"){ row in
             row.title = "Twilio from Number"
-            row.value = UserDefaultsRepository.twilioFromNumberString.value
+            row.cell.textField.placeholder = "EnterFromNumber"
+            row.cell.textField.keyboardType = UIKeyboardType.phonePad
+            if (UserDefaultsRepository.twilioFromNumberString.value != "") {
+                row.value = UserDefaultsRepository.twilioFromNumberString.value
+            }
         }.onChange { row in
-            guard let value = row.value else { return }
-            UserDefaultsRepository.twilioFromNumberString.value = value
+            UserDefaultsRepository.twilioFromNumberString.value =  row.value ?? ""
         }
         
         <<< TextRow("twilioToNumberString"){ row in
             row.title = "Twilio to Number"
-            row.value = UserDefaultsRepository.twilioToNumberString.value
+            row.cell.textField.placeholder = "EnterToNumber"
+            row.cell.textField.keyboardType = UIKeyboardType.phonePad
+            if (UserDefaultsRepository.twilioToNumberString.value != "") {
+                row.value = UserDefaultsRepository.twilioToNumberString.value
+            }
         }.onChange { row in
-            guard let value = row.value else { return }
-            UserDefaultsRepository.twilioToNumberString.value = value
+            UserDefaultsRepository.twilioToNumberString.value =  row.value ?? ""
         }
         
         let shortcutsSection = Section(header: "Shortcut names • Textstrings examples", footer: "When iOS Shortcuts are selected as Remote command method, the entries made will be forwarded as a text string when you press 'Send Remote Meal/Bolus/Override/Temp Target buttons. (The text strings can be used as input in your shortcuts).\n\nYou need to create and customize your own iOS shortcuts and use the pre defined names listed above.") {

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -452,10 +452,10 @@ class UserDefaultsRepository {
     static let tempTargetsString = UserDefaultsValue<String>(key: "tempTargetsString", default: "Exercise, Eating soon, Low treatment")
     
     // API settings
-    static let twilioSIDString = UserDefaultsValue<String>(key: "twilioSIDString", default: "EnterTheSID")
-    static let twilioSecretString = UserDefaultsValue<String>(key: "twilioSecretString", default: "EnterSecret")
-    static let twilioFromNumberString = UserDefaultsValue<String>(key: "twilioFromNumberString", default: "EnterFromNumber")
-    static let twilioToNumberString = UserDefaultsValue<String>(key: "twilioToNumberString", default: "EnterToNumber")
+    static let twilioSIDString = UserDefaultsValue<String>(key: "twilioSIDString", default: "")
+    static let twilioSecretString = UserDefaultsValue<String>(key: "twilioSecretString", default: "")
+    static let twilioFromNumberString = UserDefaultsValue<String>(key: "twilioFromNumberString", default: "")
+    static let twilioToNumberString = UserDefaultsValue<String>(key: "twilioToNumberString", default: "")
     
 
     


### PR DESCRIPTION
- Use the phone number pad for entering Twilio From Number and Twilio To Number
- Use placeholder text for Twilio From Number, Twilio To Number, SID, Secret when empty
- Allow wiping out values for all 4 Twilio parameters in settings