### PR TITLE
Fix double tap meal bug

### DIFF
--- a/LoopFollow/ViewControllers/MealViewController.swift
+++ b/LoopFollow/ViewControllers/MealViewController.swift
@@ -76,6 +76,7 @@ class MealViewController: UIViewController {
             let alertControllerBolus = UIAlertController(title: "Max setting exceeded", message: "The maximum allowed bolus of \(formattedMaxBolus) U is exceeded! Please try again with a smaller amount.", preferredStyle: .alert)
             alertControllerBolus.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
             present(alertControllerBolus, animated: true, completion: nil)
+            self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
             return
         }
         
@@ -119,6 +120,7 @@ class MealViewController: UIViewController {
             let alertController = UIAlertController(title: "Max setting exceeded", message: "The maximum allowed amount of \(maxCarbs)g is exceeded for one or more of the entries! Please try again with a smaller amount.", preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
             present(alertController, animated: true, completion: nil)
+            self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
             return // Exit the function if any value exceeds maxCarbs
         }
         

--- a/LoopFollow/ViewControllers/MealViewController.swift
+++ b/LoopFollow/ViewControllers/MealViewController.swift
@@ -162,7 +162,10 @@ class MealViewController: UIViewController {
                 self.sendMealRequest(combinedString: combinedString)
             }))
             
-            confirmationAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+            confirmationAlert.addAction(UIAlertAction(title: "Avbryt", style: .cancel, handler: { (action: UIAlertAction!) in
+                // Handle dismissal when "Cancel" is selected
+                self.handleAlertDismissal()
+            }))
             
             present(confirmationAlert, animated: true, completion: nil)
         }

--- a/LoopFollow/ViewControllers/MealViewController.swift
+++ b/LoopFollow/ViewControllers/MealViewController.swift
@@ -19,6 +19,9 @@ class MealViewController: UIViewController {
     @IBOutlet weak var mealNotes: UITextField!
     @IBOutlet weak var bolusUnits: UITextField!
     
+    var isAlertShowing = false // Property to track if alerts are currently showing
+    var isButtonDisabled = false // Property to track if the button is currently disabled
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         if UserDefaultsRepository.forceDarkMode.value {
@@ -32,6 +35,15 @@ class MealViewController: UIViewController {
     }
     
     @IBAction func sendRemoteMealPressed(_ sender: Any) {
+        // Disable the button to prevent multiple taps
+        if !isButtonDisabled {
+            isButtonDisabled = true
+            sendMealButton.isEnabled = false
+        } else {
+            return // If button is already disabled, return to prevent double registration
+        }
+        
+        
         // Retrieve the maximum carbs value from UserDefaultsRepository
         let maxCarbs = UserDefaultsRepository.maxCarbs.value
         let maxBolus = UserDefaultsRepository.maxBolus.value
@@ -138,6 +150,8 @@ class MealViewController: UIViewController {
         
         //Alert for meal without bolus
         func showMealConfirmationAlert(combinedString: String) {
+            // Set isAlertShowing to true before showing the alert
+                    isAlertShowing = true
             // Confirmation alert before sending the request
             let confirmationAlert = UIAlertController(title: "Confirmation", message: "Do you want to register this meal?", preferredStyle: .alert)
             
@@ -153,6 +167,8 @@ class MealViewController: UIViewController {
         
         //Alert for meal WITH bolus
         func showMealBolusConfirmationAlert(combinedString: String) {
+            // Set isAlertShowing to true before showing the alert
+                    isAlertShowing = true
             // Confirmation alert before sending the request
             let confirmationAlert = UIAlertController(title: "Confirmation", message: "Do you want to register this meal and give \(bolusValue) U bolus?", preferredStyle: .alert)
             
@@ -219,6 +235,13 @@ class MealViewController: UIViewController {
             }
         }
     }
+    // Function to handle alert dismissal
+    func handleAlertDismissal() {
+        // Enable the button when alerts are dismissed
+        isAlertShowing = false
+        sendMealButton.isEnabled = true
+        isButtonDisabled = false // Reset button disable status
+    }
         
     func sendMealRequest(combinedString: String) {
         // Retrieve the method value from UserDefaultsRepository
@@ -261,6 +284,7 @@ class MealViewController: UIViewController {
                         let alertController = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
                         alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                         self.present(alertController, animated: true, completion: nil)
+                        self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
                     } else if let httpResponse = response as? HTTPURLResponse {
                         if (200..<300).contains(httpResponse.statusCode) {
                             // Success: Show success alert for successful response
@@ -276,12 +300,14 @@ class MealViewController: UIViewController {
                             let alertController = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
                             alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                             self.present(alertController, animated: true, completion: nil)
+                            self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
                         }
                     } else {
                         // Failure: Show generic error alert for unexpected response
                         let alertController = UIAlertController(title: "Error", message: "Unexpected response", preferredStyle: .alert)
                         alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                         self.present(alertController, animated: true, completion: nil)
+                        self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
                     }
                 }
             }.resume()


### PR DESCRIPTION
by disabling send button from first confirmation yes/cancel to last confirmation if message was succesfully delivered or failed. Enable button again when reloading view or if Twilio reports back an http error (to be able to try again)

Solution for bug #25 

**Message success**

https://github.com/dsnallfot/LoopFollowiAPS/assets/72826201/0dc40880-aafe-44c4-b47b-1fae2d2c2e58

**Message failure**

https://github.com/dsnallfot/LoopFollowiAPS/assets/72826201/84edb0f7-d55d-4307-bfd6-99def6b443ac

