### PR TITLE
Improved UI/UX for send buttons and error alerts (+ draft for new sms…

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -11,7 +11,7 @@ jobs:
 
   identifiers:
     needs: validate
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # Uncomment to manually select latest Xcode if needed
       #- name: Select Latest Xcode
@@ -19,7 +19,7 @@ jobs:
       
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables

--- a/.github/workflows/build_LoopFollow.yml
+++ b/.github/workflows/build_LoopFollow.yml
@@ -20,15 +20,15 @@ jobs:
   build:
     name: Build
     needs: validate
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # Uncomment to manually select latest Xcode if needed
       - name: Select Latest Xcode
-        run: "sudo xcode-select --switch /Applications/Xcode_14.1.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_15.0.app/Contents/Developer"
 
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       
@@ -64,7 +64,7 @@ jobs:
 
       # Upload IPA and Symbols
       - name: Upload IPA and Symbol artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -12,7 +12,7 @@ jobs:
   certificates:
     name: Create Certificates
     needs: validate
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # Uncomment to manually select latest Xcode if needed
       #- name: Select Latest Xcode
@@ -20,7 +20,7 @@ jobs:
       
       # Checks-out the repo
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -123,7 +123,7 @@ jobs:
       TEAMID: ${{ secrets.TEAMID }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
       - name: Sync clock

--- a/LoopFollow/Application/Base.lproj/Main.storyboard
+++ b/LoopFollow/Application/Base.lproj/Main.storyboard
@@ -1246,6 +1246,9 @@
                                                                     <color key="tintColor" systemColor="labelColor"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
+                                                                    <connections>
+                                                                        <action selector="editingChanged:" destination="gGw-b9-Weh" eventType="editingChanged" id="d3e-8U-GuT"/>
+                                                                    </connections>
                                                                 </textField>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="U" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YIt-Qz-s6v">
                                                                     <rect key="frame" x="214" y="4" width="25" height="27"/>
@@ -1360,6 +1363,7 @@
                     <connections>
                         <outlet property="bolusAmount" destination="0HU-rw-87i" id="Cv5-Ig-do0"/>
                         <outlet property="bolusEntryField" destination="0HU-rw-87i" id="6h7-GW-ktK"/>
+                        <outlet property="bolusUnits" destination="0HU-rw-87i" id="f15-Va-xuC"/>
                         <outlet property="sendBolusButton" destination="omd-J4-dQH" id="PCD-uC-2iY"/>
                     </connections>
                 </viewController>

--- a/LoopFollow/Controllers/Stats.swift
+++ b/LoopFollow/Controllers/Stats.swift
@@ -70,7 +70,7 @@ class StatsData {
         
         stdDev = sqrt(partialSum / Float(bgData.count))
         if UserDefaultsRepository.units.value != "mg/dL" {
-            stdDev = Float( bgUnits.toDisplayUnits( String( stdDev ) ) ) ?? 0.0;
+            stdDev = stdDev / 18
         }
         
         if UserDefaultsRepository.useIFCC.value {

--- a/LoopFollow/ViewControllers/MealViewController.swift
+++ b/LoopFollow/ViewControllers/MealViewController.swift
@@ -8,8 +8,11 @@
 
 import UIKit
 import LocalAuthentication
+import AudioToolbox
 
-class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestable {
+class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestable  {
+    var appStateController: AppStateController?
+    
     
     @IBOutlet weak var carbsEntryField: UITextField!
     @IBOutlet weak var fatEntryField: UITextField!
@@ -17,6 +20,8 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
     @IBOutlet weak var notesEntryField: UITextField!
     @IBOutlet weak var bolusEntryField: UITextField!
     @IBOutlet weak var bolusRow: UIView!
+    @IBOutlet weak var bolusCalcRow: UIView!
+    @IBOutlet weak var bolusCalculated: UITextField!
     @IBOutlet weak var sendMealButton: UIButton!
     @IBOutlet weak var carbGrams: UITextField!
     @IBOutlet weak var fatGrams: UITextField!
@@ -24,6 +29,10 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
     @IBOutlet weak var mealNotes: UITextField!
     @IBOutlet weak var bolusUnits: UITextField!
     
+    let maxCarbs = UserDefaultsRepository.maxCarbs.value
+    let maxFatProtein = UserDefaultsRepository.maxFatProtein.value
+    let maxBolus = UserDefaultsRepository.maxBolus.value
+        
     var isAlertShowing = false // Property to track if alerts are currently showing
     var isButtonDisabled = false // Property to track if the button is currently disabled
     
@@ -33,39 +42,126 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
             overrideUserInterfaceStyle = .dark
         }
         carbsEntryField.delegate = self
+        fatEntryField.delegate = self
+        proteinEntryField.delegate = self
         self.focusCarbsEntryField()
-    
+
+        // Create a NumberFormatter instance
+        let numberFormatter = NumberFormatter()
+        numberFormatter.minimumFractionDigits = 0
+        numberFormatter.maximumFractionDigits = 1
+        
         // Check the value of hideRemoteBolus and hide the bolusRow accordingly
         if UserDefaultsRepository.hideRemoteBolus.value {
             hideBolusRow()
         }
     }
+
+        // UITextFieldDelegate method to handle text changes in carbsEntryField
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        
+        // Calculate the new text after the replacement
+        let newText = (textField.text as NSString?)?.replacingCharacters(in: range, with: string) ?? string
+        if !newText.isEmpty {
+            // Update the text in the carbsEntryField
+            textField.text = newText
+        } else {
+            // If the new text is empty, update button state
+            updateButtonState()
+            return true
+        }
+
+            // Check if the new text is a valid number
+            guard let newValue = Decimal(string: newText), newValue >= 0 else {
+                // Update button state
+                updateButtonState()
+                return false
+            }
+
+            let carbsValue = Decimal(string: carbsEntryField.text ?? "0") ?? 0
+            let fatValue = Decimal(string: fatEntryField.text ?? "0") ?? 0
+            let proteinValue = Decimal(string: proteinEntryField.text ?? "0") ?? 0
+            
+            // Check if the carbs value exceeds maxCarbs
+            if carbsValue > Decimal(maxCarbs) {
+                    // Disable button
+                    isButtonDisabled = true
+                    // Update button title
+                    sendMealButton.setAttributedTitle(NSAttributedString(string: "⛔️ Max Carbs \(maxCarbs) g", attributes: [.font: UIFont(name: "HelveticaNeue-Medium", size: 20.0)!]), for: .normal)
+            } else if fatValue > Decimal(maxFatProtein) || proteinValue > Decimal(maxFatProtein) {
+                // Disable button
+                isButtonDisabled = true
+                // Update button title
+                sendMealButton.setAttributedTitle(NSAttributedString(string: "⛔️ Max Fat/Protein \(maxFatProtein) g", attributes: [.font: UIFont(name: "HelveticaNeue-Medium", size: 20.0)!]), for: .normal)
+            } else {
+                    // Enable button
+                    isButtonDisabled = false
+                    // Check if bolusText is not "0" and not empty
+                    if let bolusText = bolusUnits.text, bolusText != "0" && !bolusText.isEmpty {
+                        // Update button title with bolus
+                        sendMealButton.setAttributedTitle(NSAttributedString(string: "Send Meal and Bolus", attributes: [.font: UIFont(name: "HelveticaNeue-Medium", size: 20.0)!]), for: .normal)
+                    } else {
+                        // Update button title without bolus
+                        sendMealButton.setAttributedTitle(NSAttributedString(string: "Send Meal", attributes: [.font: UIFont(name: "HelveticaNeue-Medium", size: 20.0)!]), for: .normal)
+                    }
+                }
+            // Update button state
+            updateButtonState()
+            return false // Return false to prevent the text field from updating its text again
+        }
+
+    // Function to round a Decimal number down to the nearest specified increment
+    func roundDown(toNearest increment: Decimal, value: Decimal) -> Decimal {
+        let doubleValue = NSDecimalNumber(decimal: value).doubleValue
+        let roundedDouble = (doubleValue * 20).rounded(.down) / 20
+        
+        return Decimal(roundedDouble)
+    }
+
+    // Function to format a Decimal number based on the locale's decimal separator
+    func formatDecimal(_ value: Decimal) -> String {
+        let doubleValue = NSDecimalNumber(decimal: value).doubleValue
+        
+        let numberFormatter = NumberFormatter()
+        numberFormatter.minimumFractionDigits = 2
+        numberFormatter.maximumFractionDigits = 2
+        numberFormatter.minimumIntegerDigits = 1
+        numberFormatter.decimalSeparator = Locale.current.decimalSeparator
+        
+        guard let formattedString = numberFormatter.string(from: NSNumber(value: doubleValue)) else {
+            fatalError("Failed to format the number.")
+        }
+        
+        return formattedString
+    }
+    
     func focusCarbsEntryField() {
-        self.carbsEntryField.becomeFirstResponder()
+            self.carbsEntryField.becomeFirstResponder()
+        }
+    
+    @IBAction func presetButtonTapped(_ sender: Any) {
+        let customActionViewController = storyboard!.instantiateViewController(withIdentifier: "remoteCustomAction") as! CustomActionViewController
+        self.present(customActionViewController, animated: true, completion: nil)
     }
     
     @IBAction func sendRemoteMealPressed(_ sender: Any) {
         // Disable the button to prevent multiple taps
-        if !isButtonDisabled {
-            isButtonDisabled = true
-            sendMealButton.isEnabled = false
-        } else {
-            return // If button is already disabled, return to prevent double registration
-        }
-        
-        
-        // Retrieve the maximum carbs value from UserDefaultsRepository
-        let maxCarbs = UserDefaultsRepository.maxCarbs.value
-        let maxBolus = UserDefaultsRepository.maxBolus.value
+                if !isButtonDisabled {
+                    isButtonDisabled = true
+                    sendMealButton.isEnabled = false
+                } else {
+                    return // If button is already disabled, return to prevent double registration
+                }
         
         // BOLUS ENTRIES
         //Process bolus entries
         guard var bolusText = bolusUnits.text else {
-            print("Error: Bolus amount not entered")
+            print("Note: Bolus amount not entered")
             return
         }
         
-        // Replace all occurrences of ',' with '.'
+        // Replace all eventual occurrences of ',' with '.
+        
         bolusText = bolusText.replacingOccurrences(of: ",", with: ".")
         
         let bolusValue: Double
@@ -74,12 +170,21 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
         } else {
             guard let bolusDouble = Double(bolusText) else {
                 print("Error: Bolus amount conversion failed")
+                // Play failure sound
+                AudioServicesPlaySystemSound(SystemSoundID(1053))
+                // Display an alert
+                let alertController = UIAlertController(title: "Error!", message: "Bolus entry is misformatted", preferredStyle: .alert)
+                alertController.addAction(UIAlertAction(title: "Change", style: .default, handler: nil))
+                present(alertController, animated: true, completion: nil)
+                self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
                 return
             }
             bolusValue = bolusDouble
         }
-        
-        if bolusValue > maxBolus {
+        //Let code remain for now - to be cleaned
+        if bolusValue > (maxBolus + 0.05) {
+            // Play failure sound
+            AudioServicesPlaySystemSound(SystemSoundID(1053))
             // Format maxBolus to display only one decimal place
             let formattedMaxBolus = String(format: "%.1f", maxBolus)
             
@@ -91,8 +196,9 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
         }
         
         // CARBS & FPU ENTRIES
+        
         guard var carbText = carbGrams.text else {
-            print("Error: Carb amount not entered")
+            print("Note: Carb amount not entered")
             return
         }
         
@@ -103,14 +209,21 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
             carbsValue = 0
         } else {
             guard let carbsDouble = Double(carbText) else {
-                print("Error: Carb amount conversion failed")
+                print("Error: Carb input value conversion failed")
+                // Play failure sound
+                AudioServicesPlaySystemSound(SystemSoundID(1053))
+                // Display an alert
+                let alertController = UIAlertController(title: "Error!", message: "Carb entry is misformatted", preferredStyle: .alert)
+                alertController.addAction(UIAlertAction(title: "Change", style: .default, handler: nil))
+                present(alertController, animated: true, completion: nil)
+                self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
                 return
             }
             carbsValue = carbsDouble
         }
         
         guard var fatText = fatGrams.text else {
-            print("Error: Fat amount not entered")
+            print("Note: Fat amount not entered")
             return
         }
         
@@ -121,14 +234,21 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
             fatsValue = 0
         } else {
             guard let fatsDouble = Double(fatText) else {
-                print("Error: Fat amount conversion failed")
+                print("Error: Fat input value conversion failed")
+                // Play failure sound
+                AudioServicesPlaySystemSound(SystemSoundID(1053))
+                // Display an alert
+                let alertController = UIAlertController(title: "Error!", message: "Fat entry is misformatted", preferredStyle: .alert)
+                alertController.addAction(UIAlertAction(title: "Change", style: .default, handler: nil))
+                present(alertController, animated: true, completion: nil)
+                self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
                 return
             }
             fatsValue = fatsDouble
         }
         
         guard var proteinText = proteinGrams.text else {
-            print("Error: Protein amount not entered")
+            print("Note: Protein amount not entered")
             return
         }
         
@@ -139,14 +259,23 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
             proteinsValue = 0
         } else {
             guard let proteinsDouble = Double(proteinText) else {
-                print("Error: Protein amount conversion failed")
+                print("Error: Protein input value conversion failed")
+                // Play failure sound
+                AudioServicesPlaySystemSound(SystemSoundID(1053))
+                // Display an alert
+                let alertController = UIAlertController(title: "Error", message: "Protein entry is misformatted", preferredStyle: .alert)
+                alertController.addAction(UIAlertAction(title: "Change", style: .default, handler: nil))
+                present(alertController, animated: true, completion: nil)
+                self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
                 return
             }
             proteinsValue = proteinsDouble
         }
         
-        if carbsValue > maxCarbs { // || fatsValue > maxCarbs || proteinsValue > maxCarbs { // Just use the maxcarbs guardrail for carb entries until we agreed upon a better approach regarding fat and protein
-            let alertController = UIAlertController(title: "Max setting exceeded", message: "The maximum allowed amount of \(maxCarbs) g is exceeded! Please try again with a smaller amount.", preferredStyle: .alert)
+        if carbsValue > maxCarbs || fatsValue > maxCarbs || proteinsValue > maxCarbs {
+            // Play failure sound
+            AudioServicesPlaySystemSound(SystemSoundID(1053))
+            let alertController = UIAlertController(title: "Max setting exceeded", message: "The maximum allowed amount of \(maxCarbs)g is exceeded for one or more of the entries! Please try again with a smaller amount.", preferredStyle: .alert)
             alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
             present(alertController, animated: true, completion: nil)
             self.handleAlertDismissal() // Enable send button after handling failure to be able to try again
@@ -165,18 +294,20 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
         
         func createCombinedString(carbs: Double, fats: Double, proteins: Double) -> String {
             let mealNotesValue = mealNotes.text ?? ""
-            var cleanedMealNotes = mealNotesValue
+            let cleanedMealNotes = mealNotesValue
+            let name = UserDefaultsRepository.caregiverName.value
+            let secret = UserDefaultsRepository.remoteSecretCode.value
             // Convert bolusValue to string and trim any leading or trailing whitespace
             let trimmedBolusValue = "\(bolusValue)".trimmingCharacters(in: .whitespacesAndNewlines)
             
-            // Construct and return the combinedString based on hideRemoteBolus setting
             if UserDefaultsRepository.hideRemoteBolus.value {
                 // Construct and return the combinedString without bolus
-                return "Meal_Carbs_\(carbsValue)g_Fat_\(fatsValue)g_Protein_\(proteinsValue)g_Note_\(cleanedMealNotes)"
+                return "Remote Meal\nCarbs: \(carbsValue)g\nFat: \(fatsValue)g\nProtein: \(proteinsValue)g\nNotes: \(cleanedMealNotes)\nEntered by: \(name)\nSecret Code: \(secret)"
             } else {
                 // Construct and return the combinedString with bolus
-                return "Meal_Carbs_\(carbsValue)g_Fat_\(fatsValue)g_Protein_\(proteinsValue)g_Note_\(cleanedMealNotes)_Insulin_\(trimmedBolusValue)"
+                return "Remote Meal\nCarbs: \(carbsValue)g\nFat: \(fatsValue)g\nProtein: \(proteinsValue)g\nNotes: \(cleanedMealNotes)\nInsulin: \(trimmedBolusValue)U\nEntered by: \(name)\nSecret Code: \(secret)"
             }
+
         }
         
         //Alert for meal without bolus
@@ -184,7 +315,7 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
             // Set isAlertShowing to true before showing the alert
                     isAlertShowing = true
             // Confirmation alert before sending the request
-            let confirmationAlert = UIAlertController(title: "Confirmation", message: "Do you want to register this meal?", preferredStyle: .alert)
+            let confirmationAlert = UIAlertController(title: "Confirm Meal", message: "Do you want to register this meal?", preferredStyle: .alert)
             
             confirmationAlert.addAction(UIAlertAction(title: "Yes", style: .default, handler: { (action: UIAlertAction!) in
                 // Proceed with sending the request
@@ -204,7 +335,7 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
             // Set isAlertShowing to true before showing the alert
                     isAlertShowing = true
             // Confirmation alert before sending the request
-            let confirmationAlert = UIAlertController(title: "Confirmation", message: "Do you want to register this meal and give \(bolusValue) U bolus?", preferredStyle: .alert)
+            let confirmationAlert = UIAlertController(title: "Confirm Meal and Bolus", message: "Do you want to register this meal and give \(bolusValue) U bolus?", preferredStyle: .alert)
             
             confirmationAlert.addAction(UIAlertAction(title: "Yes", style: .default, handler: { (action: UIAlertAction!) in
                 // Authenticate with Face ID
@@ -245,6 +376,8 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
                             if let error = authenticationError {
                                 print("Authentication failed: \(error.localizedDescription)")
                             }
+                            // Handle dismissal when authentication fails
+                            self.handleAlertDismissal()
                         }
                     }
                 }
@@ -268,10 +401,13 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
                     if let error = error {
                         print("Authentication failed: \(error.localizedDescription)")
                     }
+                    // Handle dismissal when authentication fails
+                    self.handleAlertDismissal()
                 }
             }
         }
     }
+    
     // Function to handle alert dismissal
     func handleAlertDismissal() {
         // Enable the button when alerts are dismissed
@@ -300,16 +436,22 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
             twilioRequest(combinedString: combinedString) { result in
                 switch result {
                 case .success:
+                    // Play success sound
+                    AudioServicesPlaySystemSound(SystemSoundID(1322))
+                    
                     // Show success alert
-                    let alertController = UIAlertController(title: "Success", message: "Message sent successfully!", preferredStyle: .alert)
+                    let alertController = UIAlertController(title: "Success!", message: "Message delivered", preferredStyle: .alert)
                     alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
                         // Dismiss the current view controller
                         self.dismiss(animated: true, completion: nil)
                     }))
                     self.present(alertController, animated: true, completion: nil)
                 case .failure(let error):
+                    // Play failure sound
+                    AudioServicesPlaySystemSound(SystemSoundID(1053))
+                    
                     // Show error alert
-                    let alertController = UIAlertController(title: "Error", message: error.localizedDescription, preferredStyle: .alert)
+                    let alertController = UIAlertController(title: "Error!", message: error.localizedDescription, preferredStyle: .alert)
                     alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
                     self.present(alertController, animated: true, completion: nil)
                 }
@@ -323,13 +465,40 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
         let attributes: [NSAttributedString.Key: Any] = [
             .font: UIFont(name: "HelveticaNeue-Medium", size: 20.0)!,
         ]
-        let attributedTitle: NSAttributedString
-        if let bolusText = bolusUnits.text, bolusText != "0" && bolusText != "" {
-            attributedTitle = NSAttributedString(string: "Skicka Måltid och Bolus", attributes: attributes)
+        
+        // Check if bolusText exceeds maxBolus
+        if let bolusText = bolusUnits.text?.replacingOccurrences(of: ",", with: "."),
+           let bolusValue = Decimal(string: bolusText),
+           bolusValue > Decimal(maxBolus) + 0.01 { //add 0.01 to allow entry of = maxBolus due to rounding issues with double and decimals otherwise disable it when bolusValue=maxBolus
+            
+            // Disable button
+            sendMealButton.isEnabled = false
+            
+            // Format maxBolus with two decimal places
+            let formattedMaxBolus = String(format: "%.2f", UserDefaultsRepository.maxBolus.value)
+            
+            // Update button title if bolus exceeds maxBolus
+            sendMealButton.setAttributedTitle(NSAttributedString(string: "⛔️ Max Bolus \(formattedMaxBolus) U", attributes: attributes), for: .normal)
         } else {
-            attributedTitle = NSAttributedString(string: "Skicka Måltid", attributes: [.font: UIFont(name: "HelveticaNeue-Medium", size: 20.0)!])
+            // Enable button
+            sendMealButton.isEnabled = true
+            
+            // Check if bolusText is not "0" and not empty
+            if let bolusText = bolusUnits.text, bolusText != "0" && !bolusText.isEmpty {
+                // Update button title with bolus
+                sendMealButton.setAttributedTitle(NSAttributedString(string: "Send Meal and Bolus", attributes: attributes), for: .normal)
+            } else {
+                // Update button title without bolus
+                sendMealButton.setAttributedTitle(NSAttributedString(string: "Send Meal", attributes: [.font: UIFont(name: "HelveticaNeue-Medium", size: 20.0)!]), for: .normal)
+            }
         }
-        sendMealButton.setAttributedTitle(attributedTitle, for: .normal)
+    }
+
+    
+    // Function to update button state
+    func updateButtonState() {
+        // Disable or enable button based on isButtonDisabled
+        sendMealButton.isEnabled = !isButtonDisabled
     }
 
     // Function to hide the bolusRow
@@ -340,6 +509,16 @@ class MealViewController: UIViewController, UITextFieldDelegate, TwilioRequestab
     // Function to show the bolusRow
     func showBolusRow() {
         bolusRow.isHidden = false
+    }
+    
+    // Function to hide the bolusCalcRow
+    func hideBolusCalcRow() {
+        bolusCalcRow.isHidden = true
+    }
+    
+    // Function to show the bolusCalcRow
+    func showBolusCalcRow() {
+        bolusCalcRow.isHidden = false
     }
     
     @IBAction func doneButtonTapped(_ sender: Any) {

--- a/LoopFollow/ViewControllers/RemoteSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/RemoteSettingsViewController.swift
@@ -137,7 +137,7 @@ class RemoteSettingsViewController: FormViewController {
             UserDefaultsRepository.twilioToNumberString.value =  row.value ?? ""
         }
         
-        let shortcutsSection = Section(header: "iOS Shortcut names • Textstrings examples", footer: "When iOS Shortcuts are selected as Remote command method, the entries made will be forwarded as a text string when you press 'Send Remote Meal/Bolus/Override/Temp Target buttons. (The text strings can be used as input in your shortcuts).\n\nYou need to create and customize your own iOS shortcuts and use the pre defined names listed above.") {
+        let shortcutsSection = Section(header: "iOS Shortcut names • Textstrings examples", footer: "When iOS Shortcuts are selected as Remote command method, the entries made will be forwarded as a text string when you press 'Send Remote Meal/Bolus/Override/Temp Target' buttons.The \'\n' commands in the text strings create line breaks for better readability in imessage. (The text strings can be used as input in your shortcuts).\n\nYou need to create and customize your own iOS shortcuts and use the pre defined names listed above.") {
             $0.hidden = Condition.function(["method"], { form in
                 // Retrieve the value of the segmented row
                 guard let methodRow = form.rowBy(tag: "method") as? SegmentedRow<String>,
@@ -154,7 +154,7 @@ class RemoteSettingsViewController: FormViewController {
         
         <<< TextRow("RemoteMealBolus"){ row in
             row.title = ""
-            row.value = "Remote Meal • Meal_Carbs_25g_Fat_15g_Protein_10g_Note_Testmeal_Insulin_1.0"
+            row.value = "Remote Meal • Remote Meal\\nCarbs: 25.5g\\nFat: 20g\\nProtein: 15g\\nNotes: Testmeal)\\nInsulin: 1.55U\\nEntered by: Dad\\nSecret Code: S3cr3tc0d3"
             row.cellSetup { cell, row in
                 cell.textLabel?.font = UIFont.systemFont(ofSize: 10)
             }
@@ -162,28 +162,28 @@ class RemoteSettingsViewController: FormViewController {
         
         <<< TextRow("RemoteMeal"){ row in
             row.title = ""
-            row.value = "Remote Meal • Meal_Carbs_25g_Fat_15g_Protein_10g_Note_Testmeal"
+            row.value = "Remote Meal • Remote Meal\\nCarbs: 25.5g\\nFat: 20g\\nProtein: 15g\\nNotes: Testmeal)\\nEntered by: Dad\\nSecret Code: S3cr3tc0d3"
             row.cellSetup { cell, row in
                 cell.textLabel?.font = UIFont.systemFont(ofSize: 10)
             }
         }
         <<< TextRow("RemoteBolus"){ row in
             row.title = ""
-            row.value = "Remote Bolus • Bolus_0.6"
+            row.value = "Remote Bolus • Remote Bolus\\nInsulin: 0.75U\\nEntered by: Dad\\nSecret Code: S3cr3tc0d3"
             row.cellSetup { cell, row in
                 cell.textLabel?.font = UIFont.systemFont(ofSize: 10)
             }
         }
         <<< TextRow("RemoteOverride"){ row in
             row.title = ""
-            row.value = "Remote Override • Override_🎉 Partytime"
+            row.value = "Remote Override • Remote Override\\n🎉 Partytime\\nEntered by: Dad\\nSecret Code: S3cr3tc0d3"
             row.cellSetup { cell, row in
                 cell.textLabel?.font = UIFont.systemFont(ofSize: 10)
             }
         }
         <<< TextRow("RemoteTempTarget"){ row in
             row.title = ""
-            row.value = "Remote Temp Target • TempTarget_🏃‍♂️ Exercise"
+            row.value = "Remote Temp Target • Remote Temp Target\\n🏃‍♂️ Exercise\\nEntered by: Dad\\nSecret Code: S3cr3tc0d3"
             row.cellSetup { cell, row in
                 cell.textLabel?.font = UIFont.systemFont(ofSize: 10)
             }
@@ -191,7 +191,7 @@ class RemoteSettingsViewController: FormViewController {
         
         <<< TextRow("RemoteCustomAction"){ row in
             row.title = ""
-            row.value = "Remote Custom Action • CustomAction_🍿 Popcorn"
+            row.value = "Remote Custom Action • Remote Custom Action\\n🍿 Popcorn\\nEntered by: Dad\\nSecret Code: S3cr3tc0d3"
             row.cellSetup { cell, row in
                 cell.textLabel?.font = UIFont.systemFont(ofSize: 10)
             }

--- a/LoopFollow/ViewControllers/RemoteSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/RemoteSettingsViewController.swift
@@ -307,6 +307,22 @@ class RemoteSettingsViewController: FormViewController {
             UserDefaultsRepository.maxCarbs.value = Double(value)
         }
         
+        <<< StepperRow("maxFatProtein") { row in
+            row.title = "Max Fat or Protein (g)"
+            row.cell.stepper.stepValue = 5
+            row.cell.stepper.minimumValue = 0
+            row.cell.stepper.maximumValue = 200
+            row.value = Double(UserDefaultsRepository.maxFatProtein.value)
+            row.displayValueFor = { value in
+                guard let value = value else { return nil }
+                return "\(Int(value))"
+            }
+        }.onChange { [weak self] row in
+            guard let value = row.value else { return }
+            //UserDefaultsRepository.maxFatProtein.value = Int(value)
+            UserDefaultsRepository.maxFatProtein.value = Double(value)
+        }
+        
         <<< StepperRow("maxBolus") { row in
             row.title = "Max Bolus (U)"
             row.cell.stepper.stepValue = 0.1

--- a/LoopFollow/ViewControllers/RemoteSettingsViewController.swift
+++ b/LoopFollow/ViewControllers/RemoteSettingsViewController.swift
@@ -137,7 +137,7 @@ class RemoteSettingsViewController: FormViewController {
             UserDefaultsRepository.twilioToNumberString.value =  row.value ?? ""
         }
         
-        let shortcutsSection = Section(header: "iOS Shortcut names • Textstrings examples", footer: "When iOS Shortcuts are selected as Remote command method, the entries made will be forwarded as a text string when you press 'Send Remote Meal/Bolus/Override/Temp Target' buttons.The \'\n' commands in the text strings create line breaks for better readability in imessage. (The text strings can be used as input in your shortcuts).\n\nYou need to create and customize your own iOS shortcuts and use the pre defined names listed above.") {
+        let shortcutsSection = Section(header: "iOS Shortcut names • Textstrings examples", footer: "When iOS Shortcuts are selected as Remote command method, the entries made will be forwarded as a text string when you press 'Send Remote Meal/Bolus/Override/Temp Target' buttons. The '\\n' commands in the text strings create line breaks for better readability in imessage. (The text strings can be used as input in your shortcuts).\n\nYou need to create and customize your own iOS shortcuts and use the pre defined names listed above.") {
             $0.hidden = Condition.function(["method"], { form in
                 // Retrieve the value of the segmented row
                 guard let methodRow = form.rowBy(tag: "method") as? SegmentedRow<String>,

--- a/LoopFollow/repository/UserDefaults.swift
+++ b/LoopFollow/repository/UserDefaults.swift
@@ -459,6 +459,7 @@ class UserDefaultsRepository {
     
     //Remote guardrails
     static let maxCarbs = UserDefaultsValue<Double>(key: "maxCarbs", default: 30)
+    static let maxFatProtein = UserDefaultsValue<Double>(key: "maxFatProtein", default: 30)
     static let maxBolus = UserDefaultsValue<Double>(key: "maxBolus", default: 2.0)
     
     // API settings


### PR DESCRIPTION
… formatting)

- Disable send buttons when maxCarbs, maxFatProtein or maxBolus is exceeded (as discussed in #68)
- Use 2 different guardrails. One for Max Carbs and one for Max Fat/Protein
- Always disable send button after enacting it, and always activate the button again to be able to adjust entries and try again if the process is stopped due to any error or choosing cancel in confirmation any dialog
- Present the actual guardrail setting on the disabled send button to make it easy to see what entry to adjust
- Present alerts if carbs, fat, protein or bolus entries are misformatted
- Add system sounds/vibrations for successfully delivered messages and all errors
- Reformatting of the sms strings sent (see screenshots in PR). Draft based on discussions in #47 

**Also added a couple of small necessary fixes from official LF dev**
- Fix for std dev (Björkerts commit 132ff6c)
- Update to Xcode 15 and iOS 17 SDK for App Store compliance (Björkert and dnzxys commits 79e5ab3, 8bf6da2 and 6468421